### PR TITLE
run ci on push or pr opened

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,12 @@
-name: Go
+name: Go CI test and coverage
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - '*'
 
 jobs:
 


### PR DESCRIPTION
Related to #8 

With this PR the CI checks are enabled when someone opens a pull request

<img width="956" alt="Screenshot 2022-11-14 at 08 20 23" src="https://user-images.githubusercontent.com/2587460/201549998-ba7dcd95-c8dc-4736-9cfb-864e26de8621.png">
