### PR TITLE
Add test actions badge

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Go CI test and coverage
+name: test
 
 on:
   push:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 ## Goban: Fast and Robust dataframe package in Go
 [![Go Reference](https://pkg.go.dev/badge/github.com/hrbrain/goban.svg)](https://pkg.go.dev/github.com/hrbrain/goban)
+[![test](https://github.com/hrbrain/goban/actions/workflows/ci.yaml/badge.svg)](https://github.com/hrbrain/goban/actions/workflows/ci.yaml)
 
 Goban is a fast and robust dataframe package for the Go. It is inspired by the Python package [Pandas](http://pandas.pydata.org/).
 


### PR DESCRIPTION
I add to actions test badge and rename action name to test.
It has two reason.
- It keeps badge name simple.
- This actions is currently responsible only test not coverage.  